### PR TITLE
Remove stable docs badge in README for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # TopoPlots
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://MakieOrg.github.io/TopoPlots.jl/stable)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://MakieOrg.github.io/TopoPlots.jl/dev)
 [![Build Status](https://github.com/MakieOrg/TopoPlots.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/MakieOrg/TopoPlots.jl/actions/workflows/CI.yml?query=branch%3Amaster)
 [![Coverage](https://codecov.io/gh/MakieOrg/TopoPlots.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/MakieOrg/TopoPlots.jl)


### PR DESCRIPTION
Currently running into #6 

In the mean time we can remove stable docs badge for now