### PR TITLE
replace PyCall (and Delaunay) with PythonCall

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,0 +1,9 @@
+channels = ["anaconda", "conda-forge"]
+
+[deps]
+# Conda package names and versions
+python = ">=3.7,<4"
+# CondaPkg uses mamba by default
+scipy =  ">=1.9"
+[pip.deps]
+# Pip package names and versions

--- a/Project.toml
+++ b/Project.toml
@@ -4,27 +4,23 @@ authors = ["Benedikt Ehinger", "Simon Danisch", "Beacon Biosignals, Inc."]
 version = "0.1.3"
 
 [deps]
-Delaunay = "07eb4e4e-0c6d-46ef-bc4e-83d5e5d860a9"
 Dierckx = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
-PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 ScatteredInterpolation = "3f865c0f-6dca-5f4d-999b-29fe1e7e3c92"
-SciPy = "ebc72ef8-9537-4fb0-b64e-ac76025fed2d"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Delaunay = "1.2"
 Dierckx = "0.5"
 GeometryBasics = "0.4"
 Makie = "0.17.8, 0.18, 0.19"
 Parameters = "0.12"
-PyCall = "1.93"
+PythonCall = "0.9"
 ScatteredInterpolation = "0.3.6"
-SciPy = "0.1"
 julia = "1"
 
 [extras]

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,9 +1,0 @@
-@info "Installing scipy"
-using PyCall
-try
-    run(`$(PyCall.python) -m pip install scipy`)
-catch e
-    @warn("Couldn't install scipy in TopoPlots.jl build.jl.
-           Please make sure manually, that the python PyCall uses has scipy installed")
-    rethrow(e)
-end

--- a/src/TopoPlots.jl
+++ b/src/TopoPlots.jl
@@ -1,16 +1,31 @@
 module TopoPlots
 
+using PythonCall
+
+const SciPy = PythonCall.pynew()
+const SciPy_Spatial = PythonCall.pynew()
+
+
+# taken from https://github.com/beacon-biosignals/PyMNE.jl/blob/main/src/PyMNE.jl
+function __init__()
+    # all of this is __init__() so that it plays nice with precompilation
+    # see https://github.com/cjdoris/PythonCall.jl/blob/5ea63f13c291ed97a8bacad06400acb053829dd4/src/Py.jl#L85-L96
+    PythonCall.pycopy!(SciPy, pyimport("scipy"))
+    PythonCall.pycopy!(SciPy_Spatial, pyimport("scipy.spatial"))
+    return nothing
+end
+
+
 using Makie
-using SciPy
 using LinearAlgebra
 using Statistics
 using GeometryBasics
 using GeometryBasics: origin, radius
 using Parameters
 using InteractiveUtils
-using Delaunay
 using Dierckx
 using ScatteredInterpolation
+
 
 assetpath(files...) = normpath(joinpath(dirname(@__DIR__), "assets", files...))
 

--- a/src/core-recipe.jl
+++ b/src/core-recipe.jl
@@ -104,6 +104,7 @@ function Makie.plot!(p::TopoPlot)
     if p.interpolation[] isa DelaunayMesh
         # TODO, delaunay works very differently from the other interpolators, so we can't switch interactively between them
         m = lift(delaunay_mesh, p.positions)
+        @show typeof(m.val)
         mesh!(p, m, color=p.data, colorrange=colorrange, colormap=p.colormap, shading=false)
     else
         data = lift(p.interpolation, xg, yg, padded_pos_data_bb, geometry) do interpolation, xg, yg, (points, data, _, _), geometry

--- a/test/CondaPkg.toml
+++ b/test/CondaPkg.toml
@@ -1,0 +1,8 @@
+channels = ["anaconda", "conda-forge"]
+
+[deps]
+matplotlib = ""
+python = ">=3.7,<4"
+scipy = ">=1.9"
+
+[pip.deps]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,13 +1,17 @@
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 PyMNE = "6c5003b2-cbe8-491c-a0d1-70088e6a0fd6"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-PyMNE = "=0.1.2"
+PyMNE = "0.2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,27 +1,22 @@
 using Test
-using LinearAlgebra, Statistics, TopoPlots, CairoMakie, FileIO
-using PyCall
+using PythonCall
+using TopoPlots
+using LinearAlgebra, Statistics, CairoMakie, FileIO
 try
-    PyCall.pyimport("matplotlib")
+    matplotlib = PythonCall.pyimport("matplotlib")
+    
 catch e
     # I tried adding Conda for PyPlot, which then installs matplotlib automatically.
     # It looks like this messed with mne, so that then needed manual installation...
     # Now, Conda started making problems (in a fresh CI env?!) https://github.com/MakieOrg/TopoPlots.jl/pull/20#issuecomment-1224822002
     # So, lets go back to install matplotlib manually, and let mne install automatically!
-    run(PyCall.python_cmd(`-m pip install matplotlib`))
+    #run(PyCall.python_cmd(`-m pip install matplotlib`))#
+    error("to be adressed")
 end
-const PyMNE = try
-    # XXX The hidden Conda.jl installation and the way dependency resolution works
-    # means that PyMNE sometimes needs to be rebuilt to use the correct Python.
-    using PyMNE
-    PyMNE
-catch
-    @info "PyMNE failed to load; trying to the manual way."
-    run(PyCall.python_cmd(`-m pip install mne`))
-    pyimport("mne")
-end
-using PyPlot
-PyPlot.pygui(false)
+
+using PyMNE
+import PythonPlot
+PythonPlot.pygui(false)
 
 include("percy.jl")
 
@@ -35,11 +30,11 @@ function mne_topoplot(fig, data, positions)
         (pos .- circle.center) ./ (circle.r)
     end
     x, y = first.(positions_normed), last.(positions_normed)
-    posmat = hcat(first.(positions_normed), last.(positions_normed))
-    f = PyPlot.figure()
-    PyMNE.viz.plot_topomap(data, posmat, sphere=1.1, extrapolate="box", cmap="RdBu_r", sensors=false, contours=6)
-    PyPlot.scatter(x, y, c=data, cmap="RdBu_r")
-    PyPlot.savefig("pymne_plot.png", bbox_inches="tight", pad_inches = 0, dpi = 200)
+    posmat = hcat(x, y)
+    f = PythonPlot.figure()
+    PyMNE.viz.plot_topomap(data, Py(posmat).to_numpy(), sphere=1.1, extrapolate="box", cmap="RdBu_r", sensors=false, contours=6)
+    PythonPlot.scatter(x, y, c=data, cmap="RdBu_r")
+    PythonPlot.savefig("pymne_plot.png", bbox_inches="tight", pad_inches = 0, dpi = 200)
     img = load("pymne_plot.png")
     rm("pymne_plot.png")
     s = Axis(fig; aspect=DataAspect())


### PR DESCRIPTION
PythonCall is used in PyMNE, recently we got incompatability issues, especially trying to get both running at the same time. Most users will not understand that they need to place an ENV["PYTHOn..."] = "@PyCall" in between the two packages...
Much easier to simply remove the PyCall dependency.

This also had the issue of removing Delaunay.jl, as it is a wrapper to SciPy using ... PyCall.
Also I had to remove the wrapper to SciPy.jl - as it is using PyCall as well. 

But turns out we don't really need them anyway :) Delaunay is 2 lines of code, importing SciPy I stole from PyMNE.jl (with attributions).

Some further thought:
We need SciPy (and thus PythonCall) at only two functions:

1)Delaunay: I tried replacing this with VoronoiDelaunay.jl - which worked fine to get the triangles, I even managed to generate a GeometryBasics.Mesh - but it crashed later with makie-mesh-plotting, as my Mesh is based on triangles, and not points+edges (coordinates(Gemoetry.Mesh) crashed when mesh is based on Ngons). I simply dont know enough to fix it. Maybe @Simon can push me in the right direction. I have the code still in the function, a bit ugly, but maybe it is an easy fix.

2) ClaughDoughter: This is hard to replace, I did look into the algorithm at some point, it is quite complex.


