### PR TITLE
improved mask calculation (runtime 1/5th)

### DIFF
--- a/src/core-recipe.jl
+++ b/src/core-recipe.jl
@@ -106,9 +106,9 @@ function Makie.plot!(p::TopoPlot)
         m = lift(delaunay_mesh, p.positions)
         mesh!(p, m, color=p.data, colorrange=colorrange, colormap=p.colormap, shading=false)
     else
-        mask = lift(xg,yg,geometry) do xg,yg,geometry
+        mask = lift(xg, yg, geometry) do xg, yg, geometry
             pts = Point2f.(xg' .* ones(length(yg)), ones(length(xg))' .* yg)
-            return .!(in.(pts,Ref(geometry)))
+            return @. !(in(pts, Ref(geometry)))
         end
         
         data = lift(p.interpolation, xg, yg, padded_pos_data_bb,mask) do interpolation, xg, yg, (points, data, _, _),mask


### PR DESCRIPTION
By replacing the mask loop on every observable update, we calculate the mask indices once, and apply them in one go. This slashes the runtime to 1/5th, on my machine from 350ms to 75ms
