### PR TITLE
Version 0.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TopoPlots"
 uuid = "2bdbdf9c-dbd8-403f-947b-1a4e0dd41a7a"
 authors = ["Benedikt Ehinger", "Simon Danisch", "Beacon Biosignals, Inc."]
-version = "0.2.0-DEV"
+version = "0.2.0"
 
 [deps]
 CloughTocher2DInterpolation = "b70b374f-000b-463f-88dc-37030f004bd0"


### PR DESCRIPTION
- `labels` is now a keyword argument in `eeg_topoplot`
- The full 10/05 system is now supported
- EEG coordinates for the 10/20 system are now based on a sphere instead of fsaverage head (better for visualization, worse for source localization)

(should be merged+tagged _after_ #63)