### PR TITLE
Zenodo metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -7,7 +7,7 @@
     "creators": [
 
         {
-            "affiliation": "????",
+            "affiliation": "MakieOrg",
             "name": "Danisch, Simon",
             "orcid": "0000-0001-8834-6644"
         },

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,25 @@
+{
+    "access_right": "open",
+    "license": "MIT",
+    "title": "MakieOrg/TopoPlots.jl",
+    "description": "A Julia package using Makie to generate topographical plots",
+    "upload_type": "software",
+    "creators": [
+
+        {
+            "affiliation": "????",
+            "name": "Danisch, Simon",
+            "orcid": "0000-0001-8834-6644"
+        },
+        {
+            "affiliation": "University of Stuttgart",
+            "name": "Ehinger, Benedikt",
+            "orcid": "0000-0002-6276-3332"
+        },
+        {
+            "affiliation": "Beacon Biosignals",
+            "name": "Alday, Phillip M.",
+            "orcid": "0000-0002-9984-5745"
+        }
+    ]
+}


### PR DESCRIPTION
This won't work until Zenodo is enabled on the repo by a MakieOrg admin.

@SimonDanisch can you add your desired affiliation?

I don't care about authorship order, so @SimonDanisch and @behinger feel free to suggest an alternative.